### PR TITLE
Correction of duplicate background variable

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,7 +1,6 @@
 .navbar-lewagon {
   justify-content: space-between;
   background: $go-red;
-  background: $gnome-red;
   z-index: 10;
 }
 


### PR DESCRIPTION
il fallait retirer 
  la variable `$gnomes-red `
  du fichier `app/assets/stylesheets/components/_navbar.scss`
pour que ça rentre dans l'ordre 